### PR TITLE
gunicorn timeout should match SUPERSET_WEBSERVER_TIMEOUT

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -29,7 +29,7 @@ elif [ "$SUPERSET_ENV" = "production" ]; then
     celery worker --app=superset.sql_lab:celery_app --pool=gevent -Ofair &
     gunicorn --bind  0.0.0.0:8088 \
         --workers $((2 * $(getconf _NPROCESSORS_ONLN) + 1)) \
-        --timeout 60 \
+        --timeout 300 \
         --limit-request-line 0 \
         --limit-request-field_size 0 \
         superset:app


### PR DESCRIPTION
Actually, SUPERSET_WEBSERVER_TIMEOUT is deprecated in 0.32 and we can remove it.
I'll review other options and update config.py in separate pr.