### PR TITLE
Require gitbase for superset container

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,12 @@
 ### Init
 
 ```
-docker-compose run --rm superset ./docker-init.sh
+GITBASE_REPOS_DIR=/some/path  docker-compose run --rm superset ./docker-init.sh
 ```
 
 to create admin user and initialize superset.
+
+Currently it would print some exceptions, just ignore them. It will be fixed after [the issue](https://github.com/src-d/gitbase/issues/808) is resolved.
 
 ### Run
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,7 @@ services:
     depends_on:
       - postgres
       - redis
+      - gitbase
 
 volumes:
   postgres:


### PR DESCRIPTION
After pull request #6 that creates views by default it's necessary to
start gitbase for init step too.

I didn't change script to ignore errors but added note in documentation
about exceptions because I expect the bug in gitbase to be fixed soon.

Signed-off-by: Maxim Sukharev <max@smacker.ru>