### PR TITLE
Sqlalchemy 1.3

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,7 +48,6 @@ COPY superset/requirements-dev.txt .
 
 RUN pip install --upgrade setuptools pip \
     && pip install -r requirements.txt -r requirements-dev.txt \
-    && pip install sqlalchemy==1.3.1 \
     && rm -rf /root/.cache/pip
 
 COPY --chown=superset:superset superset/superset superset

--- a/superset/requirements.txt
+++ b/superset/requirements.txt
@@ -62,7 +62,7 @@ selenium==3.141.0
 simplejson==3.15.0
 six==1.11.0               # via bleach, cryptography, isodate, pathlib2, polyline, pydruid, python-dateutil, sqlalchemy-utils, wtforms-json
 sqlalchemy-utils==0.32.21
-sqlalchemy==1.2.2
+sqlalchemy==1.3.1
 sqlparse==0.2.4
 unicodecsv==0.14.1
 urllib3==1.22             # via requests, selenium

--- a/superset/setup.py
+++ b/superset/setup.py
@@ -100,7 +100,7 @@ setup(
         'retry>=0.9.2',
         'selenium>=3.141.0',
         'simplejson>=3.15.0',
-        'sqlalchemy',
+        'sqlalchemy>=1.3.1,<2.0',
         'sqlalchemy-utils',
         'sqlparse',
         'unicodecsv',

--- a/superset/superset/db_engine_specs.py
+++ b/superset/superset/db_engine_specs.py
@@ -46,6 +46,7 @@ from sqlalchemy.engine import create_engine
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.sql import quoted_name, text
 from sqlalchemy.sql.expression import TextAsFrom
+from sqlalchemy.types import String, UnicodeText
 import sqlparse
 from werkzeug.utils import secure_filename
 
@@ -1363,6 +1364,18 @@ class MssqlEngineSpec(BaseEngineSpec):
         if len(data) != 0 and type(data[0]).__name__ == 'Row':
             data = [[elem for elem in r] for r in data]
         return data
+
+    column_types = [
+        (String(), re.compile(r'^(?<!N)((VAR){0,1}CHAR|TEXT|STRING)', re.IGNORECASE)),
+        (UnicodeText(), re.compile(r'^N((VAR){0,1}CHAR|TEXT)', re.IGNORECASE)),
+    ]
+
+    @classmethod
+    def get_sqla_column_type(cls, type_):
+        for sqla_type, regex in cls.column_types:
+            if regex.match(type_):
+                return sqla_type
+        return None
 
 
 class AthenaEngineSpec(BaseEngineSpec):

--- a/superset/superset/migrations/versions/4451805bbaa1_remove_double_percents.py
+++ b/superset/superset/migrations/versions/4451805bbaa1_remove_double_percents.py
@@ -66,8 +66,8 @@ def replace(source, target):
 
     query = (
         session.query(Slice, Database)
-        .join(Table)
-        .join(Database)
+        .join(Table, Slice.datasource_id == Table.id)
+        .join(Database, Table.database_id == Database.id)
         .filter(Slice.datasource_type == 'table')
         .all()
     )


### PR DESCRIPTION
Fix: #18 

Tested with:
```
docker run --rm -p 6379:6379 redis
docker run --rm -p 5432:5432 postgres:10
docker exec 51aa438cec72 psql -U postgres -c "CREATE DATABASE superset;"
docker exec 51aa438cec72 psql -U postgres -c "CREATE USER postgresuser WITH PASSWORD 'pguserpassword';"
docker run -e MYSQL_ALLOW_EMPTY_PASSWORD=yes --rm -p 3306:3306 mysql:5.6
docker exec 7e06c4a40262 mysql -u root -e "DROP DATABASE IF EXISTS superset; CREATE DATABASE superset DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci"
docker exec 7e06c4a40262 mysql -u root -e "CREATE USER 'mysqluser' IDENTIFIED BY 'mysqluserpassword';"
docker exec 7e06c4a40262 mysql -u root -e "GRANT ALL ON superset.* TO 'mysqluser';"

tox -e py36-sqlite
tox -e py36-postgres
tox -e py36-mysql (need to change localhost to 127.0.0.1 to connect by network)
tox -e flake8
tox -e pylint
```

Manual testing:
```
docker-compose down --volumes
make build
GITBASE_REPOS_DIR=<path> docker-compose run --rm superset ./docker-init.sh
GITBASE_REPOS_DIR=<path> docker-compose up
```

Run simple query using SQL Lab.
